### PR TITLE
Expanded default lemmy instances list to active users/mo > 100

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -75,15 +75,20 @@ const val DEBOUNCE_DELAY = 1000L
 const val MAX_POST_TITLE_LENGTH = 200
 
 val DEFAULT_LEMMY_INSTANCES = listOf(
-    "lemmy.ml",
-    "lemmygrad.ml",
-    "mujico.org",
-    "feddit.de",
-    "szmer.info",
     "beehaw.org",
+    "feddit.de",
     "feddit.it",
-    "sopuli.xyz",
+    "lemmy.ca",
+    "lemmy.ml",
+    "lemmy.one",
+    "lemmy.world",
+    "lemmygrad.ml",
+    "midwest.social",
+    "mujico.org",
+    "sh.itjust.works",
     "slrpnk.net",
+    "sopuli.xyz",
+    "szmer.info",
 )
 
 // convert a data class to a map


### PR DESCRIPTION
Added more Lemmy instances to the DEFAULT_LEMMY_INSTANCES list and alphabetized the list so future additions can be easier. 

Added all lemmy instances which currently show greater than 100 users/month according to: https://the-federation.info/platform/73

The following new instances were added:
lemmy.ca
lemmy.one
lemmy.world
midwest.social
sh.itjust.works